### PR TITLE
Adding capability to serialize Resource types for report generation

### DIFF
--- a/test-automation-core/src/main/kotlin/com/nortal/test/core/report/JsonFormattingUtils.kt
+++ b/test-automation-core/src/main/kotlin/com/nortal/test/core/report/JsonFormattingUtils.kt
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.StringUtils
 
 object JsonFormattingUtils {
     private val objectMapper: ObjectMapper = ObjectMapper()
-        .registerModule(JavaTimeModule())
+        .registerModules(JavaTimeModule(), ResourceSerializingModule())
         .enable(SerializationFeature.INDENT_OUTPUT)
 
     @JvmStatic

--- a/test-automation-core/src/main/kotlin/com/nortal/test/core/report/ResourceSerializingModule.kt
+++ b/test-automation-core/src/main/kotlin/com/nortal/test/core/report/ResourceSerializingModule.kt
@@ -1,0 +1,28 @@
+package com.nortal.test.core.report
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.module.SimpleSerializers
+import org.springframework.core.io.Resource
+
+class ResourceSerializingModule : SimpleModule() {
+
+    override fun setupModule(context: SetupContext) {
+        val serializers = SimpleSerializers()
+        serializers.addSerializer(Resource::class.java, ResourceSerializer())
+        context.addSerializers(serializers)
+    }
+
+}
+
+class ResourceSerializer : JsonSerializer<Resource>() {
+    override fun serialize(value: Resource, gen: JsonGenerator, serializers: SerializerProvider) {
+        gen.writeStartObject()
+        gen.writeStringField("filename", value.filename)
+        gen.writeStringField("contentLength", value.contentLength().toString())
+        gen.writeEndObject()
+    }
+
+}


### PR DESCRIPTION
Without this when running integration tests on API-s that return some Resource, the test will fail because it can't generate a report out of that type (ObjectMapper don't know how to turn it into proper JSON).